### PR TITLE
Fully fix iterparse() defusing on Python 3.6

### DIFF
--- a/defusedxml/common.py
+++ b/defusedxml/common.py
@@ -11,6 +11,7 @@ from types import MethodType
 PY3 = sys.version_info[0] == 3
 PY26 = sys.version_info[:2] == (2, 6)
 PY31 = sys.version_info[:2] == (3, 1)
+PY33 = sys.version_info[:2] == (3, 3)
 
 
 class DefusedXmlException(ValueError):
@@ -126,7 +127,9 @@ def _generate_etree_functions(DefusedXMLParser, _TreeBuilder,
                 bind(xmlparser, "defused_external_entity_ref_handler",
                      "ExternalEntityRefHandler")
             return it
-    elif PY3:
+    elif PY33:
+        # pure-Python iterparse() is completely hidden on Python 3.3,
+        # we have to use the backing _IterParseIterator
         def iterparse(source, events=None, parser=None, forbid_dtd=False,
                       forbid_entities=True, forbid_external=True):
             close_source = False
@@ -140,7 +143,7 @@ def _generate_etree_functions(DefusedXMLParser, _TreeBuilder,
                                           forbid_external=forbid_external)
             return _IterParseIterator(source, events, parser, close_source)
     else:
-        # Python 2.7
+        # Python 2.7, Python 3.2, Python 3.4+
         def iterparse(source, events=None, parser=None, forbid_dtd=False,
                       forbid_entities=True, forbid_external=True):
             if parser is None:


### PR DESCRIPTION
Python 3.3 did a very thorough job of hiding the pure-Python
iterparse() from defusedxml, so we had to not use iterparse()
directly, but find and use the pure-Python _IterParseIterator
instead. This trick breaks with Python 3.6, though, because
_IterParseIterator is no longer accessible externally at all.

However, it turns out Python 3.3's approach to iterparse() was
a one-off: the implementation of the C accelerator stuff was
changed again in 3.4, and from 3.4 onwards we should be getting
the pure-Python iterparse() again. So we can make the private
iterator access dodge specific to Python 3.3, and just use the
simple code which uses iterparse() directly - which we were
only using for Python 2.7 until now - for Python 3.2 and 3.4+.

**NOTE** please check this carefully! I'm by no means an expert on this kind of low-level import logic, so please make sure I got this right and we're really getting all the requisite pure-Python bits. But it does, at least, pass the test suite, for me.