### PR TITLE
Fix a typo and test with Python 3.7

### DIFF
--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -59,9 +59,12 @@ if PY3:
     _XMLParser, _iterparse, ParseError = _get_py3_cls()
 
 
+_sentinel = ['sentinel']
+
+
 class DefusedXMLParser(_XMLParser):
 
-    def __init__(self, html=0, target=None, encoding=None,
+    def __init__(self, html=_sentinel, target=None, encoding=None,
                  forbid_dtd=False, forbid_entities=True,
                  forbid_external=True):
         # Python 2.x old style class

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pep8py2,pep8py3,doc
+envlist = py27,py34,py35,py36,py37,pep8py2,pep8py3,doc
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
  - Set the default of DefusedXMLParser's 'html' argumento to ['sentinel']
    to avoids deprecation warnings with Python 3.7;
  - Add py37 to tox.ini test environments.

    modified:   defusedxml/ElementTree.py
    modified:   tox.ini