### PR TITLE
Remove the html argument

### DIFF
--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -61,11 +61,11 @@ if PY3:
 
 class DefusedXMLParser(_XMLParser):
 
-    def __init__(self, html=0, target=None, encoding=None,
+    def __init__(self, target=None, encoding=None,
                  forbid_dtd=False, forbid_entities=True,
                  forbid_external=True):
         # Python 2.x old style class
-        _XMLParser.__init__(self, html, target, encoding)
+        _XMLParser.__init__(self, target=target, encoding=encoding)
         self.forbid_dtd = forbid_dtd
         self.forbid_entities = forbid_entities
         self.forbid_external = forbid_external

--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -65,7 +65,7 @@ class DefusedXMLParser(_XMLParser):
                  forbid_dtd=False, forbid_entities=True,
                  forbid_external=True):
         # Python 2.x old style class
-        _XMLParser.__init__(self, target=target, encoding=encoding)
+        _XMLParser.__init__(self, target=target, encoding=encoding) 
         self.forbid_dtd = forbid_dtd
         self.forbid_entities = forbid_entities
         self.forbid_external = forbid_external

--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -65,7 +65,7 @@ class DefusedXMLParser(_XMLParser):
                  forbid_dtd=False, forbid_entities=True,
                  forbid_external=True):
         # Python 2.x old style class
-        _XMLParser.__init__(self, target=target, encoding=encoding) 
+        _XMLParser.__init__(self, target=target, encoding=encoding)
         self.forbid_dtd = forbid_dtd
         self.forbid_entities = forbid_entities
         self.forbid_external = forbid_external

--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -61,7 +61,7 @@ if PY3:
 
 class DefusedXMLParser(_XMLParser):
 
-    def __init__(self, target=None, encoding=None,
+    def __init__(self, html=0, target=None, encoding=None,
                  forbid_dtd=False, forbid_entities=True,
                  forbid_external=True):
         # Python 2.x old style class


### PR DESCRIPTION
This argument has been deprecated since 3.4 and will be removed in future Python versions. See https://docs.python.org/3.7/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLParser