### PR TITLE
html argument removed from ElementTree.XMLParser

### DIFF
--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -65,7 +65,7 @@ class DefusedXMLParser(_XMLParser):
                  forbid_dtd=False, forbid_entities=True,
                  forbid_external=True):
         # Python 2.x old style class
-        _XMLParser.__init__(self, html, target, encoding)
+        _XMLParser.__init__(self, target=target, encoding=encoding)
         self.forbid_dtd = forbid_dtd
         self.forbid_entities = forbid_entities
         self.forbid_external = forbid_external


### PR DESCRIPTION
as per [https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLParser](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLParser) 
html argument is removed from ElementTree.XMLParser