### PR TITLE
Update Black URL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,7 +23,7 @@ defusedxml -- defusing XML bombs and other exploits
     :alt: PyPI downloads
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/ambv/black
+    :target: https://github.com/python/black
     :alt: Code style: black
 
 ..


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190