### PR TITLE
Fix xml.etree.ElementTree module import for Python 3

### DIFF
--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -9,19 +9,45 @@ from __future__ import print_function, absolute_import
 
 import sys
 import warnings
-from xml.etree.ElementTree import TreeBuilder as _TreeBuilder
-from xml.etree.ElementTree import parse as _parse
-from xml.etree.ElementTree import tostring
 
 from .common import PY3
 
 if PY3:
     import importlib
+
+    def _get_py3_cls():
+        """Python 3.3 hides the pure Python code but defusedxml requires it.
+
+        The code is based on test.support.import_fresh_module().
+        """
+        pymodname = "xml.etree.ElementTree"
+        cmodname = "_elementtree"
+
+        pymod = sys.modules.pop(pymodname, None)
+        cmod = sys.modules.pop(cmodname, None)
+
+        sys.modules[cmodname] = None
+        pure_pymod = importlib.import_module(pymodname)
+        if cmod is not None:
+            sys.modules[cmodname] = cmod
+        else:
+            sys.modules.pop(cmodname)
+        if pymod is not None:
+            sys.modules[pymodname] = pymod
+        else:
+            sys.modules.pop(pymodname)
+
+        return pure_pymod.XMLParser, pure_pymod.iterparse, pure_pymod.ParseError
+
+    _XMLParser, _iterparse, ParseError = _get_py3_cls()
 else:
     from xml.etree.ElementTree import XMLParser as _XMLParser
     from xml.etree.ElementTree import iterparse as _iterparse
     from xml.etree.ElementTree import ParseError
 
+from xml.etree.ElementTree import TreeBuilder as _TreeBuilder
+from xml.etree.ElementTree import parse as _parse
+from xml.etree.ElementTree import tostring
 
 from .common import (
     DTDForbidden,
@@ -31,36 +57,6 @@ from .common import (
 )
 
 __origin__ = "xml.etree.ElementTree"
-
-
-def _get_py3_cls():
-    """Python 3.3 hides the pure Python code but defusedxml requires it.
-
-    The code is based on test.support.import_fresh_module().
-    """
-    pymodname = "xml.etree.ElementTree"
-    cmodname = "_elementtree"
-
-    pymod = sys.modules.pop(pymodname, None)
-    cmod = sys.modules.pop(cmodname, None)
-
-    sys.modules[cmodname] = None
-    pure_pymod = importlib.import_module(pymodname)
-    if cmod is not None:
-        sys.modules[cmodname] = cmod
-    else:
-        sys.modules.pop(cmodname)
-    sys.modules[pymodname] = pymod
-
-    _XMLParser = pure_pymod.XMLParser
-    _iterparse = pure_pymod.iterparse
-    ParseError = pure_pymod.ParseError
-
-    return _XMLParser, _iterparse, ParseError
-
-
-if PY3:
-    _XMLParser, _iterparse, ParseError = _get_py3_cls()
 
 _sentinel = object()
 

--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -28,13 +28,17 @@ if PY3:
 
         sys.modules[cmodname] = None
         pure_pymod = importlib.import_module(pymodname)
+
         if cmod is not None:
             sys.modules[cmodname] = cmod
         else:
             sys.modules.pop(cmodname)
+
         if pymod is not None:
+            sys.modules["xml.etree"].ElementTree = pymod
             sys.modules[pymodname] = pymod
         else:
+            sys.modules.pop("xml.etree")
             sys.modules.pop(pymodname)
 
         return pure_pymod.XMLParser, pure_pymod.iterparse, pure_pymod.ParseError

--- a/defusedxml/common.py
+++ b/defusedxml/common.py
@@ -16,16 +16,14 @@ if not hasattr(xml.parsers.expat, "ParserCreate"):
 
 
 class DefusedXmlException(ValueError):
-    """Base exception
-    """
+    """Base exception"""
 
     def __repr__(self):
         return str(self)
 
 
 class DTDForbidden(DefusedXmlException):
-    """Document type definition is forbidden
-    """
+    """Document type definition is forbidden"""
 
     def __init__(self, name, sysid, pubid):
         super(DTDForbidden, self).__init__()
@@ -39,8 +37,7 @@ class DTDForbidden(DefusedXmlException):
 
 
 class EntitiesForbidden(DefusedXmlException):
-    """Entity definition is forbidden
-    """
+    """Entity definition is forbidden"""
 
     def __init__(self, name, value, base, sysid, pubid, notation_name):
         super(EntitiesForbidden, self).__init__()
@@ -57,8 +54,7 @@ class EntitiesForbidden(DefusedXmlException):
 
 
 class ExternalReferenceForbidden(DefusedXmlException):
-    """Resolving an external reference is forbidden
-    """
+    """Resolving an external reference is forbidden"""
 
     def __init__(self, context, base, sysid, pubid):
         super(ExternalReferenceForbidden, self).__init__()
@@ -73,8 +69,7 @@ class ExternalReferenceForbidden(DefusedXmlException):
 
 
 class NotSupportedError(DefusedXmlException):
-    """The operation is not supported
-    """
+    """The operation is not supported"""
 
 
 def _apply_defusing(defused_mod):

--- a/defusedxml/lxml.py
+++ b/defusedxml/lxml.py
@@ -31,8 +31,7 @@ warnings.warn(
 
 
 class RestrictedElement(_etree.ElementBase):
-    """A restricted Element class that filters out instances of some classes
-    """
+    """A restricted Element class that filters out instances of some classes"""
 
     __slots__ = ()
     # blacklist = (etree._Entity, etree._ProcessingInstruction, etree._Comment)
@@ -75,8 +74,7 @@ class RestrictedElement(_etree.ElementBase):
 
 
 class GlobalParserTLS(threading.local):
-    """Thread local context for custom parser instances
-    """
+    """Thread local context for custom parser instances"""
 
     parser_config = {
         "resolve_entities": False,


### PR DESCRIPTION
This PR should fix the import of the C-optimized *ElementTree* module instead of the pure-Python version, an issue that happens in Python 3 when *defusedxml.ElementTree* module is already imported.