### PR TITLE
Feature proposal: `defusedxml.ElementTree.fromstringlist`

### DIFF
--- a/defusedxml/common.py
+++ b/defusedxml/common.py
@@ -131,4 +131,25 @@ def _generate_etree_functions(DefusedXMLParser, _TreeBuilder, _parse, _iterparse
         parser.feed(text)
         return parser.close()
 
+    def fromstringlist(sequence, forbid_dtd=False, forbid_entities=True, forbid_external=True):
+        """Parse XML document from sequence of string fragments.
+
+        *sequence* is a list of other sequence, *parser* is an optional parser
+        instance, defaulting to DefusedXMLParser.
+
+        Returns an Element instance.
+        """
+
+        parser = DefusedXMLParser(
+            target=_TreeBuilder(),
+            forbid_dtd=forbid_dtd,
+            forbid_entities=forbid_entities,
+            forbid_external=forbid_external,
+        )
+
+        for text in sequence:
+            parser.feed(text)
+
+        return parser.close()
+
     return parse, iterparse, fromstring


### PR DESCRIPTION
## Motivation

* The function `xml.etree.ElementTree.fromstringlist` parses a sequence to a XML document.
* It was not present in "defusedxml", so I wrote an implementation similar to `defusedxml.ElementTree.fromstring`, with the standard library as reference (https://github.com/python/cpython/blob/3.8/Lib/xml/etree/ElementTree.py).

## Tests

I have run the tests with `python tests.py` and got:
```
...............................................................        
---------------------------------------------------------------------- 
Ran 63 tests in 0.126s

OK
```

## Proposed future changes

If the feature gets approved, I will then update [tests.py](https://github.com/tiran/defusedxml/blob/master/tests.py), [ 	README.md](https://github.com/tiran/defusedxml/blob/master/README.md) and [CHANGES.txt](https://github.com/tiran/defusedxml/blob/master/CHANGES.txt) accordingly.

## Notes

The function is documented, following the standard library documentation style for `xml.etree.ElementTree.fromstringlist`.

Have a nice day !