### PR TITLE
cElementTree no longer works in Python 3.9

### DIFF
--- a/defusedxml/cElementTree.py
+++ b/defusedxml/cElementTree.py
@@ -7,9 +7,9 @@
 """
 from __future__ import absolute_import
 
-from xml.etree.cElementTree import TreeBuilder as _TreeBuilder
-from xml.etree.cElementTree import parse as _parse
-from xml.etree.cElementTree import tostring
+from xml.etree.ElementTree import TreeBuilder as _TreeBuilder
+from xml.etree.ElementTree import parse as _parse
+from xml.etree.ElementTree import tostring
 
 # iterparse from ElementTree!
 from xml.etree.ElementTree import iterparse as _iterparse


### PR DESCRIPTION
It has been deprecated alias for ElementTree for a long time.

I know this is a design decision about keeping backward compatibility but this small fix can do the job and fix related issues.