### PR TITLE
Keep imports of xml.etree.ElementTree the same

### DIFF
--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -39,6 +39,7 @@ def _get_py3_cls():
     The code is based on test.support.import_fresh_module().
     """
     pymodname = "xml.etree.ElementTree"
+    pymodparent = "xml.etree"
     cmodname = "_elementtree"
 
     pymod = sys.modules.pop(pymodname, None)
@@ -51,6 +52,7 @@ def _get_py3_cls():
     else:
         sys.modules.pop(cmodname)
     sys.modules[pymodname] = pymod
+    sys.modules[pymodparent].ElementTree = pymod
 
     _XMLParser = pure_pymod.XMLParser
     _iterparse = pure_pymod.iterparse


### PR DESCRIPTION
Before this change, the following fails:

  from xml.etree import ElementTree as FirstElementTree
  from defusedxml import ElementTree as DefusedElementTree
  from xml.etree import ElementTree as SecondElementTree
  assert FirstElementTree is SecondElementTree

_get_py3_cls puts the original module back in sys.modules to prevent this.
But its re-import overwrites the 'ElementTree' attribute of the xml.etree
package, and that is what the import machinery uses.

Fix it by putting the original module back on xml.etree too.