### PR TITLE
Re-add cElementTree module and deprecate it

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+defusedxml 0.7.0.rc2
+--------------------
+
+*Release date: ??-Jan-2021*
+
+- Re-add and deprecate ``defusedxml.cElementTree``
+- Use GitHub Actions instead of TravisCI
+
 defusedxml 0.7.0.rc1
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -716,6 +716,13 @@ See <https://www.python.org/psf/license> for licensing details.
     Injection](https://www.owasp.org/index.php/Testing_for_XML_Injection_\(OWASP-DV-008\))
 # Changelog
 
+## defusedxml 0.7.0.rc2
+
+*Release date: ??-Jan-2021*
+
+  - Re-add and deprecate `defusedxml.cElementTree`
+  - Use GitHub Actions instead of TravisCI
+
 ## defusedxml 0.7.0.rc1
 
 *Release date: 04-May-2020*

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ defuse\_stdlib() (*experimental*)
 
 ### defusedxml.cElementTree
 
-**NOTE** `defusedxml.cElementTree` is not available in Python 3.9+
+**NOTE** `defusedxml.cElementTree` is deprecated and will be removed in
+a future release. Import from `defusedxml.ElementTree` instead.
 
 parse(), iterparse(), fromstring(), XMLParser
 

--- a/README.txt
+++ b/README.txt
@@ -317,7 +317,8 @@ defuse_stdlib() (*experimental*)
 defusedxml.cElementTree
 -----------------------
 
-**NOTE** ``defusedxml.cElementTree`` is not available in Python 3.9+
+**NOTE** ``defusedxml.cElementTree`` is deprecated and will be removed in a
+future release. Import from ``defusedxml.ElementTree`` instead.
 
 parse(), iterparse(), fromstring(), XMLParser
 

--- a/defusedxml/__init__.py
+++ b/defusedxml/__init__.py
@@ -7,6 +7,8 @@
 """
 from __future__ import print_function, absolute_import
 
+import warnings
+
 from .common import (
     DefusedXmlException,
     DTDForbidden,
@@ -14,7 +16,6 @@ from .common import (
     ExternalReferenceForbidden,
     NotSupportedError,
     _apply_defusing,
-    _HAVE_CELEMENTTREE,
 )
 
 
@@ -25,10 +26,8 @@ def defuse_stdlib():
     """
     defused = {}
 
-    if _HAVE_CELEMENTTREE:
+    with warnings.catch_warnings():
         from . import cElementTree
-    else:
-        cElementTree = None
     from . import ElementTree
     from . import minidom
     from . import pulldom
@@ -41,6 +40,7 @@ def defuse_stdlib():
     defused[xmlrpc] = None
 
     defused_mods = [
+        cElementTree,
         ElementTree,
         minidom,
         pulldom,
@@ -48,8 +48,6 @@ def defuse_stdlib():
         expatbuilder,
         expatreader,
     ]
-    if _HAVE_CELEMENTTREE:
-        defused_mods.append(cElementTree)
 
     for defused_mod in defused_mods:
         stdlib_mod = _apply_defusing(defused_mod)

--- a/defusedxml/__init__.py
+++ b/defusedxml/__init__.py
@@ -56,7 +56,7 @@ def defuse_stdlib():
     return defused
 
 
-__version__ = "0.7.0.rc1"
+__version__ = "0.7.0.rc2"
 
 __all__ = [
     "DefusedXmlException",

--- a/defusedxml/cElementTree.py
+++ b/defusedxml/cElementTree.py
@@ -7,10 +7,9 @@
 """
 from __future__ import absolute_import
 
-from .common import _generate_etree_functions, _HAVE_CELEMENTTREE
+import warnings
 
-if not _HAVE_CELEMENTTREE:
-    raise ImportError("cElementTree has been removed from Python 3.9")
+from .common import _generate_etree_functions
 
 from xml.etree.cElementTree import TreeBuilder as _TreeBuilder
 from xml.etree.cElementTree import parse as _parse
@@ -23,6 +22,12 @@ from .ElementTree import DefusedXMLParser
 
 __origin__ = "xml.etree.cElementTree"
 
+
+warnings.warn(
+    "defusedxml.cElementTree is deprecated, import from defusedxml.ElementTree instead.",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
 # XMLParse is a typo, keep it for backwards compatibility
 XMLTreeBuilder = XMLParse = XMLParser = DefusedXMLParser

--- a/defusedxml/common.py
+++ b/defusedxml/common.py
@@ -9,8 +9,6 @@ import sys
 import xml.parsers.expat
 
 PY3 = sys.version_info[0] == 3
-# Python 3.9 removed cElementTree module
-_HAVE_CELEMENTTREE = sys.version_info < (3, 9, 0)
 
 # Fail early when pyexpat is not installed correctly
 if not hasattr(xml.parsers.expat, "ParserCreate"):

--- a/defusedxml/lxml.py
+++ b/defusedxml/lxml.py
@@ -24,7 +24,7 @@ tostring = _etree.tostring
 
 
 warnings.warn(
-    "defusedxml.lxml is no longer supported and will be removed in a " "future release.",
+    "defusedxml.lxml is no longer supported and will be removed in a future release.",
     category=DeprecationWarning,
     stacklevel=2,
 )

--- a/tests.py
+++ b/tests.py
@@ -18,23 +18,21 @@ from defusedxml import (
     ExternalReferenceForbidden,
     NotSupportedError,
 )
-from defusedxml.common import PY3, _HAVE_CELEMENTTREE
+from defusedxml.common import PY3
 
 
-if _HAVE_CELEMENTTREE:
+if sys.version_info < (3, 7):
+    warnings.filterwarnings("once", category=DeprecationWarning)
+
+
+with warnings.catch_warnings(record=True) as cetree_warnings:
     from defusedxml import cElementTree
-else:
-    cElementTree = None
 
 
 try:
     import gzip
 except ImportError:
     gzip = None
-
-
-if sys.version_info < (3, 7):
-    warnings.filterwarnings("once", category=DeprecationWarning)
 
 
 try:
@@ -211,9 +209,13 @@ class TestDefusedElementTree(BaseTests):
         assert self.module.XMLParse is parser
 
 
-@unittest.skipUnless(_HAVE_CELEMENTTREE, "Python 3.9 has removed cElementTree")
 class TestDefusedcElementTree(TestDefusedElementTree):
     module = cElementTree
+
+    def test_celementtree_warnings(self):
+        self.assertTrue(cetree_warnings)
+        self.assertEqual(cetree_warnings[0].category, DeprecationWarning)
+        self.assertIn("tests.py", cetree_warnings[0].filename)
 
 
 class TestDefusedMinidom(BaseTests):


### PR DESCRIPTION
``xml.etree.ElementTree`` was re-added before Python 3.9.0 release. The
alias will be removed in a future release.

Signed-off-by: Christian Heimes <christian@python.org>