### PR TITLE
Restore xml.etree.ElementTree after patch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ defusedxml 0.7.0.rc2
 
 - Re-add and deprecate ``defusedxml.cElementTree``
 - Use GitHub Actions instead of TravisCI
+- Restore ``ElementTree`` attribute of ``xml.etree`` module after patching
 
 defusedxml 0.7.0.rc1
 --------------------

--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ See <https://www.python.org/psf/license> for licensing details.
 
   - Re-add and deprecate `defusedxml.cElementTree`
   - Use GitHub Actions instead of TravisCI
+  - Restore `ElementTree` attribute of `xml.etree` module after patching
 
 ## defusedxml 0.7.0.rc1
 

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 import warnings
 
+from xml.etree import ElementTree as orig_elementtree
 from xml.sax.saxutils import XMLGenerator
 from xml.sax import SAXParseException
 from pyexpat import ExpatError
@@ -207,6 +208,11 @@ class TestDefusedElementTree(BaseTests):
         assert self.module.XMLTreeBuilder is parser
         assert self.module.XMLParser is parser
         assert self.module.XMLParse is parser
+
+    def test_import_order(self):
+        from xml.etree import ElementTree as second_elementtree
+
+        self.assertIs(orig_elementtree, second_elementtree)
 
 
 class TestDefusedcElementTree(TestDefusedElementTree):


### PR DESCRIPTION
Restore ``ElementTree`` attribute of ``xml.etree`` module after patching

Closes: https://github.com/tiran/defusedxml/issues/54
Co-authored-by: Marien Zwart <marienz@google.com>
Signed-off-by: Christian Heimes <christian@python.org>