### PR TITLE
Fix regression defusedxml.ElementTree.ParseError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ defusedxml 0.8.0.dev1
 
 - Drop support for Python 2.7, 3.4, and 3.5.
 - Add ``defusedxml.ElementTree.fromstringlist()``
+- Fix regression ``defusedxml.ElementTree.ParseError`` (#63)
+  The ``ParseError`` exception is now the same class object as
+  ``xml.etree.ElementTree.ParseError`` again.
 
 
 defusedxml 0.7.0

--- a/README.md
+++ b/README.md
@@ -720,6 +720,9 @@ See <https://www.python.org/psf/license> for licensing details.
 
   - Drop support for Python 2.7, 3.4, and 3.5.
   - Add `defusedxml.ElementTree.fromstringlist()`
+  - Fix regression `defusedxml.ElementTree.ParseError` (\#63) The
+    `ParseError` exception is now the same class object as
+    `xml.etree.ElementTree.ParseError` again.
 
 ## defusedxml 0.7.0
 

--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -9,6 +9,7 @@ from __future__ import print_function, absolute_import
 
 import sys
 import warnings
+from xml.etree.ElementTree import ParseError
 from xml.etree.ElementTree import TreeBuilder as _TreeBuilder
 from xml.etree.ElementTree import parse as _parse
 from xml.etree.ElementTree import tostring
@@ -51,12 +52,13 @@ def _get_py3_cls():
 
     _XMLParser = pure_pymod.XMLParser
     _iterparse = pure_pymod.iterparse
-    ParseError = pure_pymod.ParseError
+    # patch pure module to use ParseError from C extension
+    pure_pymod.ParseError = ParseError
 
-    return _XMLParser, _iterparse, ParseError
+    return _XMLParser, _iterparse
 
 
-_XMLParser, _iterparse, ParseError = _get_py3_cls()
+_XMLParser, _iterparse = _get_py3_cls()
 
 _sentinel = object()
 

--- a/defusedxml/cElementTree.py
+++ b/defusedxml/cElementTree.py
@@ -19,6 +19,7 @@ from .ElementTree import (
     parse,
     tostring,
     DefusedXMLParser,
+    ParseError,
 )
 
 __origin__ = "xml.etree.cElementTree"
@@ -31,6 +32,7 @@ warnings.warn(
 )
 
 __all__ = [
+    "ParseError",
     "XML",
     "XMLParse",
     "XMLParser",

--- a/tests.py
+++ b/tests.py
@@ -218,6 +218,15 @@ class TestDefusedElementTree(BaseTests):
 
         self.assertIs(orig_elementtree, second_elementtree)
 
+    def test_orig_parseerror(self):
+        # https://github.com/tiran/defusedxml/issues/63
+        self.assertIs(self.module.ParseError, orig_elementtree.ParseError)
+        try:
+            self.parseString("invalid")
+        except Exception as e:
+            self.assertIsInstance(e, orig_elementtree.ParseError)
+            self.assertIsInstance(e, self.module.ParseError)
+
 
 class TestDefusedcElementTree(TestDefusedElementTree):
     module = cElementTree


### PR DESCRIPTION
The ``defusedxml.ElementTree.ParseError`` exception is now the same class object
as ``xml.etree.ElementTree.ParseError`` again. The regression was
introduced by new patching code as part of PR #60.

See: https://github.com/tiran/defusedxml/pull/60
Fixes: https://github.com/tiran/defusedxml/issues/63
Signed-off-by: Christian Heimes <christian@python.org>