### PR TITLE
[0.7] Fix regression defusedxml.ElementTree.ParseError

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,20 @@
 on:
   push:
-    branches: ["master"]
+    branches: 
+      - master
+      - main
+      - v*.x
   pull_request:
-    branches: ["master"]
+    branches:
+      - master
+      - main
+      - v*.x
   workflow_dispatch:
 
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+defusedxml 0.7.1
+---------------------
+
+*Release date: ??-Mar-2021*
+
+- Fix regression ``defusedxml.ElementTree.ParseError`` (#63)
+  The ``ParseError`` exception is now the same class object as
+  ``xml.etree.ElementTree.ParseError`` again.
+
+
 defusedxml 0.7.0
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -716,6 +716,14 @@ See <https://www.python.org/psf/license> for licensing details.
     Injection](https://www.owasp.org/index.php/Testing_for_XML_Injection_\(OWASP-DV-008\))
 # Changelog
 
+## defusedxml 0.7.1
+
+*Release date: ??-Mar-2021*
+
+  - Fix regression `defusedxml.ElementTree.ParseError` (\#63) The
+    `ParseError` exception is now the same class object as
+    `xml.etree.ElementTree.ParseError` again.
+
 ## defusedxml 0.7.0
 
 *Release date: 4-Mar-2021*

--- a/defusedxml/ElementTree.py
+++ b/defusedxml/ElementTree.py
@@ -9,6 +9,7 @@ from __future__ import print_function, absolute_import
 
 import sys
 import warnings
+from xml.etree.ElementTree import ParseError
 from xml.etree.ElementTree import TreeBuilder as _TreeBuilder
 from xml.etree.ElementTree import parse as _parse
 from xml.etree.ElementTree import tostring
@@ -20,7 +21,6 @@ if PY3:
 else:
     from xml.etree.ElementTree import XMLParser as _XMLParser
     from xml.etree.ElementTree import iterparse as _iterparse
-    from xml.etree.ElementTree import ParseError
 
 
 from .common import (
@@ -63,13 +63,15 @@ def _get_py3_cls():
 
     _XMLParser = pure_pymod.XMLParser
     _iterparse = pure_pymod.iterparse
-    ParseError = pure_pymod.ParseError
+    # patch pure module to use ParseError from C extension
+    pure_pymod.ParseError = ParseError
 
-    return _XMLParser, _iterparse, ParseError
+    return _XMLParser, _iterparse
 
 
 if PY3:
-    _XMLParser, _iterparse, ParseError = _get_py3_cls()
+    _XMLParser, _iterparse = _get_py3_cls()
+
 
 _sentinel = object()
 

--- a/defusedxml/__init__.py
+++ b/defusedxml/__init__.py
@@ -56,7 +56,7 @@ def defuse_stdlib():
     return defused
 
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "DefusedXmlException",

--- a/defusedxml/cElementTree.py
+++ b/defusedxml/cElementTree.py
@@ -18,7 +18,19 @@ from xml.etree.cElementTree import tostring
 # iterparse from ElementTree!
 from xml.etree.ElementTree import iterparse as _iterparse
 
-from .ElementTree import DefusedXMLParser
+# This module is an alias for ElementTree just like xml.etree.cElementTree
+from .ElementTree import (
+    XML,
+    XMLParse,
+    XMLParser,
+    XMLTreeBuilder,
+    fromstring,
+    iterparse,
+    parse,
+    tostring,
+    DefusedXMLParser,
+    ParseError,
+)
 
 __origin__ = "xml.etree.cElementTree"
 
@@ -38,6 +50,7 @@ parse, iterparse, fromstring = _generate_etree_functions(
 XML = fromstring
 
 __all__ = [
+    "ParseError",
     "XML",
     "XMLParse",
     "XMLParser",

--- a/tests.py
+++ b/tests.py
@@ -214,6 +214,15 @@ class TestDefusedElementTree(BaseTests):
 
         self.assertIs(orig_elementtree, second_elementtree)
 
+    def test_orig_parseerror(self):
+        # https://github.com/tiran/defusedxml/issues/63
+        self.assertIs(self.module.ParseError, orig_elementtree.ParseError)
+        try:
+            self.parseString("invalid")
+        except Exception as e:
+            self.assertIsInstance(e, orig_elementtree.ParseError)
+            self.assertIsInstance(e, self.module.ParseError)
+
 
 class TestDefusedcElementTree(TestDefusedElementTree):
     module = cElementTree


### PR DESCRIPTION
The ``defusedxml.ElementTree.ParseError`` exception is now the same class object
as ``xml.etree.ElementTree.ParseError`` again. The regression was
introduced by new patching code as part of PR #60.

See: https://github.com/tiran/defusedxml/pull/60
Fixes: https://github.com/tiran/defusedxml/issues/63
Signed-off-by: Christian Heimes <christian@python.org>