### PR TITLE
Only warn when importing cElementTree directly

### DIFF
--- a/defusedxml/__init__.py
+++ b/defusedxml/__init__.py
@@ -26,8 +26,8 @@ def defuse_stdlib():
     """
     defused = {}
 
-    with warnings.catch_warnings():
-        from . import cElementTree
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="defusedxml")
+    from . import cElementTree
     from . import ElementTree
     from . import minidom
     from . import pulldom


### PR DESCRIPTION
Ran,
```
$ python setup.py install --user
$ python -W error -c 'import defusedxml; defusedxml.defuse_stdlib()'
```
and confirmed no warning.

Closes https://github.com/tiran/defusedxml/issues/88
___
```
black: OK ✔ in 2.28 seconds
pep8py3: install_package> python -I -m pip install --force-reinstall --no-deps /home/jamison/code/third-party/defusedxml/.tox/.tmp/package/64/defusedxml-0.8.0.dev1.tar.gz
pep8py3: commands[0]> .tox/pep8py3/bin/python -m flake8
pep8py3: OK ✔ in 2.15 seconds
doc: install_package> python -I -m pip install --force-reinstall --no-deps /home/jamison/code/third-party/defusedxml/.tox/.tmp/package/65/defusedxml-0.8.0.dev1.tar.gz
doc: commands[0]> python setup.py check --restructuredtext --metadata --strict
running check
.pkg: _exit> python /usr/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py36: SKIP (0.01 seconds)
  py37: OK (2.48=setup[2.36]+cmd[0.12] seconds)
  py38: SKIP (0.00 seconds)
  py39: OK (2.37=setup[2.24]+cmd[0.13] seconds)
  py310: OK (2.11=setup[1.99]+cmd[0.12] seconds)
  py311: OK (2.24=setup[2.07]+cmd[0.17] seconds)
  black: OK (2.28=setup[2.12]+cmd[0.16] seconds)
  pep8py3: OK (2.15=setup[1.97]+cmd[0.19] seconds)
  doc: OK (2.14=setup[1.95]+cmd[0.19] seconds)
  congratulations :) (15.85 seconds)

```