### PR TITLE
GitHub Action to find typos and lint Python code

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -1,0 +1,19 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://docs.astral.sh/ruff
+name: codespell_and_ruff
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell
+    - run: ruff --output-format=github .

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ protection](https://libexpat.github.io/doc/api/latest/#billion-laughs)
 with sensible default limits to mitigate billion laughs and quadratic
 blowup.
 
-Offical binaries from python.org use libexpat 2.4.0 since 3.7.12,
+Official binaries from python.org use libexpat 2.4.0 since 3.7.12,
 3.8.12, 3.9.7, and 3.10.0 (August 2021). Third party vendors may use
 older or newer versions of expat. `pyexpat.version_info` contains the
 current runtime version of libexpat.

--- a/README.txt
+++ b/README.txt
@@ -429,7 +429,7 @@ load external entities from files or network resources.
 Update to expat to 2.4.0 or newer. It has `billion laughs protection`_ with
 sensible default limits to mitigate billion laughs and quadratic blowup.
 
-Offical binaries from python.org use libexpat 2.4.0 since 3.7.12, 3.8.12,
+Official binaries from python.org use libexpat 2.4.0 since 3.7.12, 3.8.12,
 3.9.7, and 3.10.0 (August 2021). Third party vendors may use older or
 newer versions of expat. ``pyexpat.version_info`` contains the current
 runtime version of libexpat.

--- a/defusedxml/lxml.py
+++ b/defusedxml/lxml.py
@@ -35,7 +35,7 @@ class RestrictedElement(_etree.ElementBase):
 
     __slots__ = ()
     # blacklist = (etree._Entity, etree._ProcessingInstruction, etree._Comment)
-    blacklist = _etree._Entity
+    blacklist = _etree._Entity  # noqa: SLF001
 
     def _filter(self, iterator):
         blacklist = self.blacklist
@@ -119,7 +119,7 @@ def check_docinfo(elementtree, forbid_dtd=False, forbid_entities=True):
             raise DTDForbidden(docinfo.doctype, docinfo.system_url, docinfo.public_id)
         if forbid_entities and not LXML3:
             # lxml < 3 has no iterentities()
-            raise NotSupportedError("Unable to check for entity declarations " "in lxml 2.x")
+            raise NotSupportedError("Unable to check for entity declarations in lxml 2.x")
 
     if forbid_entities:
         for dtd in docinfo.internalDTD, docinfo.externalDTD:

--- a/other/exploit_webdav.py
+++ b/other/exploit_webdav.py
@@ -33,7 +33,7 @@ xml = xml.replace("QUAD", "&a;" * 1000)
 headers = {"Content-Type": "text/xml", "Content-Length": len(xml), "Depth": 1}
 
 if url.username:
-    auth = base64.b64encode(":".join((url.username, url.password)))
+    auth = base64.b64encode(f"{url.username}:{url.password}")
     headers["Authorization"] = "Basic %s" % auth
 
 con = httplib.HTTPConnection(url.hostname, int(url.port))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,78 @@
 [tool.black]
 line-length = 98
 target-version = ['py36', 'py37', 'py38']
+
+[tool.codespell]
+ignore-words-list = "clen"
+
+[tool.ruff]
+ignore = ["PLR6301", "RUF012"]
+line-length = 98
+target-version = "py37"
+select = [
+  "AIR",    # Airflow
+  "ASYNC",  # flake8-async
+  "BLE",    # flake8-blind-except
+  "C4",     # flake8-comprehensions
+  "C90",    # McCabe cyclomatic complexity
+  "DJ",     # flake8-django
+  "DTZ",    # flake8-datetimez
+  "E",      # pycodestyle
+  "F",      # Pyflakes
+  "FA",     # flake8-future-annotations
+  "FIX",    # flake8-fixme
+  "FLY",    # flynt
+  "FURB",   # refurb
+  "G",      # flake8-logging-format
+  "ICN",    # flake8-import-conventions
+  "INT",    # flake8-gettext
+  "ISC",    # flake8-implicit-str-concat
+  "LOG",    # flake8-logging
+  "NPY",    # NumPy-specific rules
+  "PD",     # pandas-vet
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PYI",    # flake8-pyi
+  "Q",      # flake8-quotes
+  "RSE",    # flake8-raise
+  "RUF",    # Ruff-specific rules
+  "SLF",    # flake8-self
+  "SLOT",   # flake8-slots
+  "T10",    # flake8-debugger
+  "TCH",    # flake8-type-checking
+  "TID",    # flake8-tidy-imports
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "A",    # flake8-builtins
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "B",    # flake8-bugbear
+  # "COM",  # flake8-commas
+  # "CPY",  # flake8-copyright
+  # "D",    # pydocstyle
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "EXE",  # flake8-executable
+  # "FBT",  # flake8-boolean-trap
+  # "I",    # isort
+  # "INP",  # flake8-no-pep420
+  # "N",    # pep8-naming
+  # "PT",   # flake8-pytest-style
+  # "PTH",  # flake8-use-pathlib
+  # "RET",  # flake8-return
+  # "S",    # flake8-bandit
+  # "SIM",  # flake8-simplify
+  # "T20",  # flake8-print
+  # "TD",   # flake8-todos
+  # "TRY",  # tryceratops
+  # "UP",   # pyupgrade
+]
+
+[tool.ruff.per-file-ignores]
+"tests.py" =  ["FIX002"]
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["int", "str"]
+max-args = 8    # Default: 5

--- a/tests.py
+++ b/tests.py
@@ -78,8 +78,7 @@ class DefusedTestCase(unittest.TestCase):
     def get_content(self, xmlfile):
         mode = "rb" if self.content_binary else "r"
         with io.open(xmlfile, mode) as f:
-            data = f.read()
-        return data
+            return f.read()
 
 
 class BaseTests(DefusedTestCase):
@@ -228,7 +227,7 @@ class TestDefusedElementTree(BaseTests):
         self.assertIs(self.module.ParseError, orig_elementtree.ParseError)
         try:
             self.parseString("invalid")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             self.assertIsInstance(e, orig_elementtree.ParseError)
             self.assertIsInstance(e, self.module.ParseError)
 


### PR DESCRIPTION
[Codespell](https://github.com/codespell-project/codespell#readme) can find and fix common misspellings in text files. It’s designed primarily for checking misspelled words in source code, but it can be used with other files as well.

[Ruff](https://beta.ruff.rs/) supports [over 600 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

`ruff --output-format=github .` provides intuitive GitHub Annotations to contributors...

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)
