### PR TITLE
fix: Filter warning when defusing cElementTree

### DIFF
--- a/defusedxml/__init__.py
+++ b/defusedxml/__init__.py
@@ -27,6 +27,7 @@ def defuse_stdlib():
     defused = {}
 
     with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="defusedxml")
         from . import cElementTree
     from . import ElementTree
     from . import minidom


### PR DESCRIPTION
The `catch_warnings` was missing a filter to ignore the deprecation warning.

Closes: #88