### PR TITLE
doc: Update README for 0.8.0rc2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+defusedxml 0.8.0rc2
+-------------------
+
+- Silence deprecation warning in `defuse_stdlib`.
+- Update lxml safety information
+
 defusedxml 0.8.0rc1
 -------------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.7.0   | :white_check_mark: |
-| 0.6.0   | :white_check_mark: |
-| < 0.6   | :x:                |
+| 0.8.0   | :white_check_mark: |
+| 0.7.1   | :white_check_mark: |
+| < 0.7.1 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/defusedxml/__init__.py
+++ b/defusedxml/__init__.py
@@ -57,7 +57,7 @@ def defuse_stdlib():
     return defused
 
 
-__version__ = "0.8.0rc1"
+__version__ = "0.8.0rc2"
 
 __all__ = [
     "DefusedXmlException",


### PR DESCRIPTION
- warn about `defuse_stdlib`
- update lxml safety instructions
- show how to check for stdlib and expat mitigations