### PR TITLE
test: Test with 3.13, PyPy 3.9, and no lxml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13-dev"
+          - "pypy3.9"
         image: 
           - "ubuntu-22.04"
         include:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+defusedxml 0.8.0
+----------------
+
+*Release date: 2023*
+
+- Fix testing without lxml
+- Test on 3.13-dev and PyPy 3.9
+
+
 defusedxml 0.8.0rc2
 -------------------
 
@@ -8,6 +17,7 @@ defusedxml 0.8.0rc2
 
 - Silence deprecation warning in `defuse_stdlib`.
 - Update lxml safety information
+
 
 defusedxml 0.8.0rc1
 -------------------

--- a/README.md
+++ b/README.md
@@ -715,6 +715,13 @@ during working hours as part of semantics's open source initiative.
     Injection](https://www.owasp.org/index.php/Testing_for_XML_Injection_(OWASP-DV-008))
 # Changelog
 
+## defusedxml 0.8.0
+
+*Release date: 2023*
+
+-   Fix testing without lxml
+-   Test on 3.13-dev and PyPy 3.9
+
 ## defusedxml 0.8.0rc2
 
 *Release date: 29-Sep-2023*

--- a/tests.py
+++ b/tests.py
@@ -351,7 +351,7 @@ class TestDefusedSax(BaseTests):
 class TestDefusedLxml(BaseTests):
     module = lxml
 
-    cyclic_error = lxml_etree.XMLSyntaxError
+    cyclic_error = getattr(lxml_etree, "XMLSyntaxError", None)
 
     content_binary = True
 
@@ -359,14 +359,14 @@ class TestDefusedLxml(BaseTests):
         try:
             tree = self.module.parse(xmlfile, **kwargs)
         except lxml_etree.XMLSyntaxError:
-            self.skipTest("lxml detects entityt reference loop")
+            self.skipTest("lxml detects entity reference loop")
         return self.module.tostring(tree)
 
     def parseString(self, xmlstring, **kwargs):
         try:
             tree = self.module.fromstring(xmlstring, **kwargs)
         except lxml_etree.XMLSyntaxError:
-            self.skipTest("lxml detects entityt reference loop")
+            self.skipTest("lxml detects entity reference loop")
         return self.module.tostring(tree)
 
     if not LXML3:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,black,pep8py3,doc
+envlist = {py36,py37,py38,py39,py310,py311,py312}-{lxml,nolxml},py313,pypy39,black,pep8py3,doc
 skip_missing_interpreters = true
 
 [testenv]
 commands =
     {envpython} {toxinidir}/tests.py
 deps =
-    lxml
+    lxml: lxml
 
 [testenv:black]
 commands = black --check --verbose \
@@ -48,3 +48,5 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    pypy-3.9: pypy39


### PR DESCRIPTION
- Add tox configuration for Python 3.13 and PyPy 3.9
- Add tox env for testing with and without lxml installed
- Fixed tests when lxml is missing